### PR TITLE
[20211121] S3 > SNS > lambdaまで

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -16,7 +16,11 @@ Resources:
         - x86_64
       Tracing: Active
       Role: !GetAtt ThumbnailFunctionLambdaRole.Arn
-
+      Events:
+        SNSTopicEvent:
+          Type: SNS
+          Properties:
+            Topic: !Ref SNSTopic
   ThumbnailFunctionLambdaRole:
     Type: AWS::IAM::Role
     Properties:
@@ -54,3 +58,28 @@ Resources:
                   - logs:CreateLogStream
                 Resource:
                   - "arn:aws:logs:*:*:*"
+  SNSTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: "TopicForThumbnailFunctionLambda"
+      TopicName: "TopicForThumbnailFunctionLambda"
+  SNSTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties: 
+      PolicyDocument:
+        Version: "2008-10-17"
+        Id: "from_s3_policy_id"
+        Statement:
+          -
+            Sid: SendToSns
+            Effect: Allow
+            Principal:
+              AWS: "*"
+            Action:
+              SNS:Publish
+            Resource: !Ref SNSTopic
+            Condition:
+              ArnLike:
+                aws:SourceArn: arn:aws:s3:::tatsukoni-lambda-demo
+      Topics: 
+        - !Ref SNSTopic

--- a/thumbnail/event/event.go
+++ b/thumbnail/event/event.go
@@ -1,0 +1,55 @@
+package event
+
+import (
+	"encoding/json"
+	"github.com/aws/aws-lambda-go/events"
+)
+
+type snsRecordCollection struct {
+	Record []snsMessage `json:"Records"`
+}
+
+type snsMessage struct {
+	EventName string `json:"eventName"`
+	S3Message SnsS3Message `json:"s3"`
+}
+
+type SnsS3Message struct {
+	Bucket SnsS3BucketMessage `json:"bucket"`
+	Object SnsS3ObjectMessage `json:"object"`
+}
+
+type SnsS3BucketMessage struct {
+	Name string `json:"name"`
+}
+
+type SnsS3ObjectMessage struct {
+	Key string `json:"key"`
+}
+
+type S3Info struct {
+	Bucket string
+	Key  string
+}
+
+func GetS3TrigerInfo(SNSEvent events.SNSEvent) *S3Info {
+	for _, record := range SNSEvent.Records {
+		var snsRecordCollection snsRecordCollection
+		if err := json.Unmarshal([]byte(record.SNS.Message), &snsRecordCollection); err != nil {
+			return getS3TrigerErrorInfo()
+		}
+		for _, snsRecord := range snsRecordCollection.Record {
+			return &S3Info {
+				Bucket: snsRecord.S3Message.Bucket.Name,
+				Key: snsRecord.S3Message.Object.Key}
+		}
+		return getS3TrigerErrorInfo()
+	}
+	return getS3TrigerErrorInfo()
+}
+
+func getS3TrigerErrorInfo() *S3Info {
+	return &S3Info {
+		Bucket: "no-info",
+		Key: "no-info"}
+}

--- a/thumbnail/handler.go
+++ b/thumbnail/handler.go
@@ -1,14 +1,16 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
+	event "thumbnail/event"
+	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
-func HandleRequest() (string, error) {
-	fmt.Println("hello world!")
-	fmt.Println("output test v2")
+func HandleRequest(ctx context.Context, events events.SNSEvent) (string, error) {
+	fmt.Println(event.GetS3TrigerInfo(events).Key)
 	return "", nil
 }
 


### PR DESCRIPTION
S3にファイルアップロード > SNS通知 > lambdaでアップロードファイル名取得

# 参考情報
## lambdaイベントトリガー設定
- https://qiita.com/icck/items/4d1debd8b1710b25a2b2
- https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md
- https://docs.aws.amazon.com/ja_jp/AmazonS3/latest/userguide/notification-how-to-filtering.html

## S3 > SNS > lambda
- https://docs.aws.amazon.com/ja_jp/AmazonS3/latest/userguide/NotificationHowTo.html
- https://hack-le.com/aws-sam-clisnslambdapython-3-8s3/
- https://docs.aws.amazon.com/ja_jp/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html
- https://dev.classmethod.jp/articles/s3-sns-lambda/

## Go言語の書き方(json周りの整形)
- https://qiita.com/niiyz/items/3f522c0e5a32de916ec6

## CloudFormation !Refとかの使い所
- https://dev.classmethod.jp/articles/cloudformation-tips-focused-on-refs/

# 補足
S3 > lambdaへのトリガは、sam記述の際S3バケットを新設しないといけない などの制約があったので、不採用。
https://ameblo.jp/hanju8888amb/entry-12626474891.html