### PR TITLE
[20211122] 画像リサイズを追加

### DIFF
--- a/thumbnail/event/event.go
+++ b/thumbnail/event/event.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"encoding/json"
+
 	"github.com/aws/aws-lambda-go/events"
 )
 

--- a/thumbnail/go.mod
+++ b/thumbnail/go.mod
@@ -5,4 +5,5 @@ go 1.15
 require (
 	github.com/aws/aws-lambda-go v1.27.0
 	github.com/aws/aws-sdk-go v1.42.9
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 )

--- a/thumbnail/go.sum
+++ b/thumbnail/go.sum
@@ -10,6 +10,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
# 概要
ひとまず`"github.com/nfnt/resize"`を使う方法で実現

# 参考
## Go言語でのリサイズ実装
- https://zenn.dev/a_ichi1/articles/c2c86b3e8017e7

## io.Readerについて
- https://qiita.com/ktnyt/items/8ede94469ba8b1399b12

## Image > io.Readerへの変換
- https://blog.narumium.net/2019/02/15/%E3%80%90go%E3%80%91%E7%94%BB%E5%83%8F%E5%87%A6%E7%90%86%E3%80%90io-reader%E3%80%91/